### PR TITLE
Correct postprocessing script mount issue

### DIFF
--- a/post scripts/nzbget.py
+++ b/post scripts/nzbget.py
@@ -60,7 +60,7 @@ else:
     mode = 'failed'
 
 # send it to watcher
-url = '{}/postprocessing?apikey={}&mode={}&guid={}&downloadid={}&path={}'.format(watcherhost, watcherapi, mode, guid, downloadid, path)
+url = '{}/core/postprocessing?apikey={}&mode={}&guid={}&downloadid={}&path={}'.format(watcherhost, watcherapi, mode, guid, downloadid, path)
 request = urllib2.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
 response = json.loads(urllib2.urlopen(request).read())
 

--- a/post scripts/sabnzbd.py
+++ b/post scripts/sabnzbd.py
@@ -67,7 +67,7 @@ else:
     print 'Seinding {} to Watcher as Failed.'.format(name)
     mode = 'failed'
 
-url = 'http://{}/postprocessing?apikey={}&mode={}&guid={}&downloadid={}&path={}'.format(watcheraddress, watcherapi, mode, guid, downloadid, path)
+url = 'http://{}/core/postprocessing?apikey={}&mode={}&guid={}&downloadid={}&path={}'.format(watcheraddress, watcherapi, mode, guid, downloadid, path)
 request = urllib2.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
 response = json.loads(urllib2.urlopen(request).read())
 

--- a/watcher.py
+++ b/watcher.py
@@ -148,13 +148,11 @@ if __name__ == '__main__':
 
     cherrypy.tree.mount(api.API(),
                         '{}/api'.format(mount),
-                        '{}api'.format(mount),
                         api.API.conf
                         )
 
     cherrypy.tree.mount(postprocessing.Postprocessing(),
-                        '{}/postprocessing'.format(mount),
-                        '{}postprocessing'.format(mount),
+                        '{}core/postprocessing'.format(mount),
                         postprocessing.Postprocessing.conf
                         )
 


### PR DESCRIPTION
This addresses #22 and helps resolve postprocessing conflicts between reverse proxy and vanilla installs.  Similar to the additional paths (ajax/static) needed to integrate reverse proxy functionality, the post-processing script needs a discrete named path in order to be called by installs that are not using a reverse proxy.

The two hosted post-processing scripts have been updated in this pull request/