### PR TITLE
Quick-add position changes based on container height

### DIFF
--- a/static/css/add_movie.css
+++ b/static/css/add_movie.css
@@ -88,7 +88,7 @@ span.quickadd{
     position: absolute;
     cursor: pointer;
     background-color: #212121;
-    bottom: 4em;
+    top: 15em;
     left: 0;
     padding: 0.25em .4em .25em 0.4em;
     color:  white;


### PR DESCRIPTION
Because the height of the movie `li` container is variable based on title length and poster, calculating the absolute position from the bottom for an overlay element can be problematic.  Basing the position based on the top, which is static, means that the quick-add overlay will always be in the same place, regardless of the height of the container.  The position `top: 15em;` works well for this specific application.

Orig: [http://imgur.com/a/RHkpS](http://imgur.com/a/RHkpS)
Edit: [http://imgur.com/a/JmEjS](http://imgur.com/a/JmEjS)