### PR TITLE
Only capture first 4 characters for year field

### DIFF
--- a/static/js/add_movie/main.js
+++ b/static/js/add_movie/main.js
@@ -43,7 +43,7 @@ $(document).ready(function() {
                                 $("<i>", {class: 'fa fa-plus button_add'})
                                 ),
                             $('<img>', {src:dict['Poster'],imdbid: dict['imdbID']}),
-                            dict['Title'],' ',dict['Year'].slice(0,4)
+                            dict['Title'],' ',dict['Year'].slice(0,3)
                         )
                     ).appendTo(movie_list)
                 });


### PR DESCRIPTION
This will help sanitize results that return year data that is longer than 4 characters (`0123`).  This solution feels a bit... hackish.