### PR TITLE
Revert order of hash submission for GitHub API.

### DIFF
--- a/core/version.py
+++ b/core/version.py
@@ -320,7 +320,7 @@ class ZipUpdater(object):
             core.UPDATE_STATUS = result
             return result
 
-        compare_url = u'{}/compare/{}...{}'.format(core.GIT_API, local_hash, newest_hash)
+        compare_url = u'{}/compare/{}...{}'.format(core.GIT_API, newest_hash, local_hash)
 
         request = urllib2.Request(compare_url, headers={'User-Agent': 'Mozilla/5.0'})
         try:


### PR DESCRIPTION
I just saw that your update routine was relying on "behind_by" instead of "status" to determine whether a build is current. The fix I submitted for correct comparison order will break that check, because it will detect the new build as ahead of the old build. This reverts that change.