### PR TITLE
Fix invalid database location reference

### DIFF
--- a/watcher.py
+++ b/watcher.py
@@ -89,7 +89,7 @@ if __name__ == '__main__':
     else:
         core.DB_FILE = os.path.join(core.PROG_PATH, core.DB_FILE)
     sql = sqldb.SQL()
-    if not os.path.isfile('watcher.sqlite'):
+    if not os.path.isfile(core.DB_FILE):
         logging.info(u'SQL DB not found. Creating.')
         sql = sqldb.SQL()
         sql.create_database()


### PR DESCRIPTION
This pull request fixes #169, once this patch is applied the database correctly updates.

The issue was that in the event that the user has specified a non-default path for the database, the setup code checks `watcher.sqlite` in the current working directory, doesn't find it, and creates a new database. This database is correctly formatted, but does not include the user's data. Once the user navigates to the HTTP webserver hosted by Watcher, it loads the correct database (`core.DB_FILE`) which results in an error as the tables are incorrectly formatted for this version of Watcher.

The update is simple, make sure the code validates the database in the user's specified location, rather than the default `watcher.sqlite` in the current working directory.

Please note, this is my first pull request, please inform me if I have done something wrong.