### PR TITLE
Implement "Popular Movies" syncing

### DIFF
--- a/core/base_config.cfg
+++ b/core/base_config.cfg
@@ -18,6 +18,8 @@ retention = 1500
 imdbrss =
 imdbsync = false
 imdbfrequency = 60
+popularmoviessync = false
+popularmoviesfrequency = 60
 score_title = true
 mintorrentseeds = 1
 

--- a/core/base_config.cfg
+++ b/core/base_config.cfg
@@ -19,7 +19,7 @@ imdbrss =
 imdbsync = false
 imdbfrequency = 60
 popularmoviessync = false
-popularmoviesfrequency = 60
+popularmoviesfrequency = 24
 score_title = true
 mintorrentseeds = 1
 

--- a/core/rss/popularmovies.py
+++ b/core/rss/popularmovies.py
@@ -1,0 +1,88 @@
+import core
+from core import ajax, config, sqldb
+from core.movieinfo import TMDB
+import json
+import logging
+import urllib2
+
+logging = logging.getLogger(__name__)
+
+
+class PopularMoviesFeed(object):
+    def __init__(self):
+        self.config = config.Config()
+        self.tmdb = TMDB()
+        self.sql = sqldb.SQL()
+        self.ajax = ajax.Ajax()
+        return
+
+    def get_feed(self):
+        ''' Gets feed from popular-movies (https://github.com/sjlu/popular-movies)
+
+        Gets raw feed (JSON), sends to self.parse_xml to turn into dict
+
+        Returns True or None on success or failure (due to exception or empty movie list)
+        '''
+
+        logging.info(u'Syncing popular movie feed')
+        request = urllib2.Request('https://s3.amazonaws.com/popular-movies/movies.json',
+                                  headers={'User-Agent': 'Mozilla/5.0'})
+        try:
+            response = urllib2.urlopen(request).read()
+        except (SystemExit, KeyboardInterrupt):
+            raise
+        except Exception, e: # noqa
+            logging.error(u'Popular feed request.', exc_info=True)
+            return None
+
+        movies = json.loads(response)
+
+        if movies:
+            logging.info(u'Found {} movies in popular movies.'.format(len(movies)))
+            self.sync_new_movies(movies)
+            logging.info(u'Popular movies sync complete.')
+            return True
+        else:
+            return None
+
+    def sync_new_movies(self, movies):
+        ''' Adds new movies from rss feed
+        :params movies: list of dicts of movies
+
+        Checks last sync time and pulls new imdbids from feed.
+
+        Checks if movies are already in library and ignores.
+
+        Executes ajax.add_wanted_movie() for each new imdbid
+
+        Does not return
+        '''
+
+        new_sync_movies = []
+        for i in movies:
+
+            title = i['title']
+            imdbid = i['imdb_id']
+
+            logging.info(u'Found new watchlist movie: {} {}'.format(title, imdbid))
+
+            new_sync_movies.append(imdbid)
+
+        # check if movies already exists
+
+        existing_movies = [i['imdbid'] for i in self.sql.get_user_movies()]
+
+        movies_to_add = [i for i in new_sync_movies if i not in existing_movies]
+
+        # do quick-add procedure
+        quality = {}
+        quality['Quality'] = core.CONFIG['Quality']
+        quality['Filters'] = core.CONFIG['Filters']
+        for imdbid in movies_to_add:
+            movie_info = self.tmdb.find_imdbid(imdbid)[0]
+            if not movie_info:
+                logging.info(u'{} not found on TMDB. Cannot add.'.format(imdbid))
+                continue
+            # logging.info(u'Adding {}'.format(imdbid))
+            movie_info['quality'] = json.dumps(quality)
+            self.ajax.add_wanted_movie(json.dumps(movie_info))

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -155,8 +155,7 @@ class ImdbRssSync(object):
 
     @staticmethod
     def create():
-        interval = core.CONFIG['Search']['imdbfrequency']
-        interval = 6 * 3600
+        interval = core.CONFIG['Search']['imdbfrequency'] * 60
         now = datetime.datetime.now()
 
         hr = now.hour

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -6,7 +6,7 @@ import core
 from core.notification import Notification
 
 from core import searcher, version
-from core.rss import imdb
+from core.rss import imdb, popularmovies
 from core.plugins import taskscheduler
 
 logging = logging.getLogger(__name__)
@@ -179,4 +179,33 @@ class ImdbRssSync(object):
         imdb_rss = imdb.ImdbRss()
 
         imdb_rss.get_rss(rss_url)
+        return
+
+
+class PopularMoviesSync(object):
+
+    @staticmethod
+    def create():
+        interval = core.CONFIG['Search']['popularmoviesfrequency'] * 60
+        now = datetime.datetime.now()
+
+        hr = now.hour
+        min = now.minute + 5
+
+        if core.CONFIG['Search']['popularmoviessync'] == u'true':
+            auto_start = True
+        else:
+            auto_start = False
+
+        taskscheduler.ScheduledTask(hr, min, interval, PopularMoviesSync.sync_feed,
+                                    auto_start=auto_start)
+        return
+
+    @staticmethod
+    def sync_feed():
+        logging.info(u'Running automatic popular movies sync.')
+
+        popular_feed = popularmovies.PopularMoviesFeed()
+
+        popular_feed.get_feed()
         return

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -155,7 +155,7 @@ class ImdbRssSync(object):
 
     @staticmethod
     def create():
-        interval = core.CONFIG['Search']['imdbfrequency'] * 60
+        interval = int(core.CONFIG['Search']['imdbfrequency']) * 60
         now = datetime.datetime.now()
 
         hr = now.hour
@@ -185,7 +185,7 @@ class PopularMoviesSync(object):
 
     @staticmethod
     def create():
-        interval = core.CONFIG['Search']['popularmoviesfrequency'] * 60
+        interval = int(core.CONFIG['Search']['popularmoviesfrequency']) * 60
         now = datetime.datetime.now()
 
         hr = now.hour

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -185,7 +185,8 @@ class PopularMoviesSync(object):
 
     @staticmethod
     def create():
-        interval = int(core.CONFIG['Search']['popularmoviesfrequency']) * 60
+        # Minimum of eight hours
+        interval = max(int(core.CONFIG['Search']['popularmoviesfrequency']), 8) * 60 * 60
         now = datetime.datetime.now()
 
         hr = now.hour

--- a/templates/settings.py
+++ b/templates/settings.py
@@ -183,9 +183,9 @@ class Settings():
                 i(id='popularmoviessync', cls='fa fa-square-o checkbox', value=c[c_s]['popularmoviessync'])
                 span(u'Sync Popular Movie list ')
                 span(' every ')
-                input(type='number', min='15', id='popularmoviesfrequency', value=c[c_s]['popularmoviesfrequency'], style='width: 3.0em')
-                span(' minutes.')
-                span('*Requires restart.', cls='tip')
+                input(type='number', min='8', id='popularmoviesfrequency', value=c[c_s]['popularmoviesfrequency'], style='width: 3.0em')
+                span(' hours.')
+                span('*Requires restart, minimum of 8 hours.', cls='tip')
 
         with div(id='save', cat='search'):
             i(cls='fa fa-save')

--- a/templates/settings.py
+++ b/templates/settings.py
@@ -179,6 +179,13 @@ class Settings():
                 input(type='number', min='15', id='imdbfrequency', value=c[c_s]['imdbfrequency'], style='width: 3.0em')
                 span(' minutes.')
                 span('*Requires restart.', cls='tip')
+            with li():
+                i(id='popularmoviessync', cls='fa fa-square-o checkbox', value=c[c_s]['popularmoviessync'])
+                span(u'Sync Popular Movie list ')
+                span(' every ')
+                input(type='number', min='15', id='popularmoviesfrequency', value=c[c_s]['popularmoviesfrequency'], style='width: 3.0em')
+                span(' minutes.')
+                span('*Requires restart.', cls='tip')
 
         with div(id='save', cat='search'):
             i(cls='fa fa-save')

--- a/watcher.py
+++ b/watcher.py
@@ -142,6 +142,7 @@ if __name__ == '__main__':
     scheduler.AutoUpdateCheck.create()
     scheduler.AutoUpdateInstall.create()
     scheduler.ImdbRssSync.create()
+    scheduler.PopularMoviesSync.create()
     scheduler_plugin.plugin.subscribe()
 
     # If windows os and daemon selected, start systray


### PR DESCRIPTION
This pull request implements "Popular Movies" syncing, as per requested in #182 and #172.

Few key points I want to make clear:

1. I tried to duplicate the already-existing programming style as much as possible
2. This has the "Popular Movie" URL hard-coded, and could be changed to a config option if requested, however @sjlu has stated in #182 that using the URL is fine.
3. No error correction/handling is performed if the configuration file doesn't store an integer for the `popularmoviesfrequency` value, however, the imdb sync code I based this from also didn't handle that, so I assumed it'd be okay
4. This also fixes the hard-coded synchronization time of six hours for the IMDB synchronization script.
5. I placed the code in the `rss` folder, despite the feed not being rss. I did this because they're serving the same function, and I thought it'd be clutterful to add another directory, and felt like generalization was better in this situtation

I understand that @nosmokingbandit has previously stated they don't want to make Watcher "feature rich", and rather stick with the basics and do it well, so I completely understand if this pull request is rejected.