### PR TITLE
Set 'sort' variable

### DIFF
--- a/core/sqldb.py
+++ b/core/sqldb.py
@@ -243,7 +243,7 @@ class SQL(object):
         '''
 
         if quality in core.CONFIG['Quality']['Profiles']:
-            sort = 'ASC'
+            sort = 'DESC'
             if core.CONFIG['Quality']['Profiles'][quality]['prefersmaller']:
                 sort = 'ASC'
         else:

--- a/core/sqldb.py
+++ b/core/sqldb.py
@@ -243,6 +243,7 @@ class SQL(object):
         '''
 
         if quality in core.CONFIG['Quality']['Profiles']:
+            sort = 'ASC'
             if core.CONFIG['Quality']['Profiles'][quality]['prefersmaller']:
                 sort = 'ASC'
         else:


### PR DESCRIPTION
If a user does not have `prefersmaller` set, the sort variable never gets assigned, throwing an error:

```
ERROR 2017-02-02 19:39:40,081 cherrypy.error.34475652688.error: [02/Feb/2017:19:39:40] HTTP 
Traceback (most recent call last):
  File "/usr/share/watcher/lib/cherrypy/_cprequest.py", line 670, in respond
    response.body = self.handler()
  File "/usr/share/watcher/lib/cherrypy/lib/encoding.py", line 220, in __call__
    self.body = self.oldhandler(*args, **kwargs)
  File "/usr/share/watcher/lib/cherrypy/_cpdispatch.py", line 60, in __call__
    return self.callable(*self.args, **self.kwargs)
  File "/usr/share/watcher/core/ajax.py", line 76, in movie_status_popup
    return msp.html(imdbid)
  File "/usr/share/watcher/templates/movie_status_popup.py", line 40, in html
    self.result_list(imdbid, quality)
  File "/usr/share/watcher/templates/movie_status_popup.py", line 68, in result_list
    results = self.sql.get_search_results(imdbid, quality)
  File "/usr/share/watcher/core/sqldb.py", line 254, in get_search_results
    command = u'SELECT * FROM {} WHERE imdbid="{}" ORDER BY score DESC, size {}'.format(TABLE, imdbid, sort)
UnboundLocalError: local variable 'sort' referenced before assignment
```